### PR TITLE
feat: add bulk story creation with rate limit handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /.phpunit.result.cache
 .phpunit.cache/test-results
 /test-output
-
+.phpactor.json

--- a/src/StoryblokResponse.php
+++ b/src/StoryblokResponse.php
@@ -6,7 +6,6 @@ namespace Storyblok\ManagementApi;
 
 use Storyblok\ManagementApi\Data\StoryblokData;
 use Storyblok\ManagementApi\Data\StoryblokDataInterface;
-use Storyblok\ManagementApi\Data\StoryData;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
@@ -33,7 +32,6 @@ class StoryblokResponse implements StoryblokResponseInterface
         return $this->response;
     }
 
-
     public function data(): StoryblokDataInterface
     {
 
@@ -42,8 +40,6 @@ class StoryblokResponse implements StoryblokResponseInterface
         }
 
         return $this->dataClass::make($this->toArray());
-        //return new $dataClass($this->toArray());
-
     }
 
 

--- a/src/StoryblokResponseInterface.php
+++ b/src/StoryblokResponseInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Storyblok\ManagementApi;
 
-use Storyblok\ManagementApi\Data\StoryblokData;
 use Storyblok\ManagementApi\Data\StoryblokDataInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 

--- a/tests/Feature/StoryTest.php
+++ b/tests/Feature/StoryTest.php
@@ -12,6 +12,16 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Psr\Log\NullLogger;
 
+// This is a mock class to eliminate the sleep from the rate limit handling
+class TestStoryApi extends \Storyblok\ManagementApi\Endpoints\StoryApi
+{
+    #[\Override]
+    protected function handleRateLimit(): void
+    {
+        // No sleep and no logs for testing
+    }
+}
+
 test('Testing One Story, StoryData', function (): void {
     $responses = [
         \mockResponse("one-story", 200),
@@ -235,6 +245,190 @@ test('Testing list of stories, Params', function (): void {
     foreach ($storyblokResponse as $story) {
         expect($story->name())->toBe("My third post");
     }
+});
 
+test('createBulk handles rate limiting and creates multiple stories', function (): void {
+    $mockLogger = new class extends NullLogger {
+        public array $logs = [];
 
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->logs[] = [
+                'level' => $level,
+                'message' => $message,
+                'context' => $context
+            ];
+        }
+
+        public function warning(string|\Stringable $message, array $context = []): void
+        {
+            $this->log('warning', $message, $context);
+        }
+    };
+
+    $story1Data = [
+        'story' => [
+            'name' => 'Story 1',
+            'slug' => 'story-1',
+            'content' => ['component' => 'blog'],
+            'created_at' => '2024-02-08 09:40:59.123',
+            'published_at' => null,
+            'id' => 1,
+            'uuid' => '1234-5678'
+        ]
+    ];
+
+    $story2Data = [
+        'story' => [
+            'name' => 'Story 2',
+            'slug' => 'story-2',
+            'content' => ['component' => 'blog'],
+            'created_at' => '2024-02-08 09:41:59.123',
+            'published_at' => null,
+            'id' => 2,
+            'uuid' => '8765-4321'
+        ]
+    ];
+
+    $responses = [
+        // First story - Rate limit hit, then success
+        \mockResponse('empty-story', 429, ['error' => 'Rate limit exceeded']),
+        new MockResponse(json_encode($story1Data), [
+            'http_code' => 201,
+            'response_headers' => ['Content-Type: application/json'],
+        ]),
+        // Second story - Immediate success
+        new MockResponse(json_encode($story2Data), [
+            'http_code' => 201,
+            'response_headers' => ['Content-Type: application/json'],
+        ]),
+    ];
+
+    $client = new MockHttpClient($responses);
+    $mapiClient = ManagementApiClient::initTest($client);
+
+    // Use TestStoryApi instead of regular StoryApi
+    $storyApi = new TestStoryApi($client, '222', $mockLogger);
+
+    // Create test stories
+    $stories = [
+        StoryData::make([
+            'name' => 'Story 1',
+            'slug' => 'story-1',
+            'content' => ['component' => 'blog']
+        ]),
+        StoryData::make([
+            'name' => 'Story 2',
+            'slug' => 'story-2',
+            'content' => ['component' => 'blog']
+        ]),
+    ];
+
+    // Execute bulk creation
+    $createdStories = iterator_to_array($storyApi->createBulk($stories));
+
+    // Verify number of created stories
+    expect($createdStories)->toHaveCount(2);
+
+    // Verify rate limit warning was logged
+    $hasRateLimitWarning = false;
+    foreach ($mockLogger->logs as $log) {
+        if ($log['level'] === 'warning' && $log['message'] === 'Rate limit reached while creating story, retrying...') {
+            $hasRateLimitWarning = true;
+            break;
+        }
+    }
+
+    expect($hasRateLimitWarning)->toBeTrue();
+
+    // Verify created stories
+    expect($createdStories[0]->name())->toBe('Story 1');
+    expect($createdStories[1]->name())->toBe('Story 2');
+    expect($createdStories[0]->slug())->toBe('story-1');
+    expect($createdStories[1]->slug())->toBe('story-2');
+});
+
+test('createBulk throws exception when max retries is reached', function (): void {
+    $mockLogger = new class extends NullLogger {
+        public array $logs = [];
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->logs[] = [
+                'level' => $level,
+                'message' => $message,
+                'context' => $context
+            ];
+        }
+
+        public function warning(string|\Stringable $message, array $context = []): void
+        {
+            $this->log('warning', $message, $context);
+        }
+
+        public function error(string|\Stringable $message, array $context = []): void
+        {
+            $this->log('error', $message, $context);
+        }
+    };
+
+    // Create responses that always return rate limit error (429)
+    // We need MAX_RETRIES + 1 responses to trigger the exception
+    $responses = array_fill(0, 4, new MockResponse(json_encode([
+        'error' => 'Rate limit exceeded'
+    ]), [
+        'http_code' => 429,
+        'response_headers' => ['Content-Type: application/json'],
+    ]));
+
+    $client = new MockHttpClient($responses);
+    $mapiClient = ManagementApiClient::initTest($client);
+
+    // Use TestStoryApi instead of regular StoryApi
+    $storyApi = new TestStoryApi($client, '222', $mockLogger);
+
+    // Create test story
+    $stories = [
+        StoryData::make([
+            'name' => 'Story 1',
+            'slug' => 'story-1',
+            'content' => ['component' => 'blog']
+        ]),
+    ];
+
+    // Execute bulk creation and expect exception
+    expect(fn (): array => iterator_to_array($storyApi->createBulk($stories)))
+        ->toThrow(
+            \Storyblok\ManagementApi\Exceptions\StoryblokApiException::class,
+            'Rate limit exceeded maximum retries'
+        );
+
+    // Verify warning logs for each retry
+    $warningCount = 0;
+    $hasErrorLog = false;
+
+    foreach ($mockLogger->logs as $log) {
+        if ($log['level'] === 'warning' &&
+            $log['message'] === 'Rate limit reached while creating story, retrying...'
+        ) {
+            ++$warningCount;
+        }
+
+        if ($log['level'] === 'error' &&
+            $log['message'] === 'Max retries reached while creating story'
+        ) {
+            $hasErrorLog = true;
+        }
+    }
+
+    // We should see MAX_RETRIES number of warning logs
+    expect($warningCount)->toBe(3)
+        ->and($hasErrorLog)->toBeTrue();
+
+    // Verify the last log context contains story information
+    $lastErrorLog = array_filter($mockLogger->logs, fn($log): bool => $log['level'] === 'error');
+    $lastErrorLog = end($lastErrorLog);
+
+    expect($lastErrorLog['context'])->toHaveKey('story_name')
+        ->and($lastErrorLog['context']['story_name'])->toBe('Story 1');
 });

--- a/tests/Feature/StoryTest.php
+++ b/tests/Feature/StoryTest.php
@@ -9,6 +9,7 @@ use Storyblok\ManagementApi\QueryParameters\Filters\QueryFilters;
 use Storyblok\ManagementApi\QueryParameters\PaginationParams;
 use Storyblok\ManagementApi\QueryParameters\StoriesParams;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Psr\Log\NullLogger;
 
@@ -293,15 +294,9 @@ test('createBulk handles rate limiting and creates multiple stories', function (
     $responses = [
         // First story - Rate limit hit, then success
         \mockResponse('empty-story', 429, ['error' => 'Rate limit exceeded']),
-        new MockResponse(json_encode($story1Data), [
-            'http_code' => 201,
-            'response_headers' => ['Content-Type: application/json'],
-        ]),
+        new JsonMockResponse($story1Data, ['http_code' => 201]),
         // Second story - Immediate success
-        new MockResponse(json_encode($story2Data), [
-            'http_code' => 201,
-            'response_headers' => ['Content-Type: application/json'],
-        ]),
+        new JsonMockResponse($story2Data, ['http_code' => 201]),
     ];
 
     $client = new MockHttpClient($responses);
@@ -374,11 +369,10 @@ test('createBulk throws exception when max retries is reached', function (): voi
 
     // Create responses that always return rate limit error (429)
     // We need MAX_RETRIES + 1 responses to trigger the exception
-    $responses = array_fill(0, 4, new MockResponse(json_encode([
+    $responses = array_fill(0, 4, new JsonMockResponse([
         'error' => 'Rate limit exceeded'
-    ]), [
-        'http_code' => 429,
-        'response_headers' => ['Content-Type: application/json'],
+    ], [
+        'http_code' => 429
     ]));
 
     $client = new MockHttpClient($responses);


### PR DESCRIPTION
# Add Bulk Story Creation with Rate Limit Handling

## Description
This PR adds a new `createBulk` method to the StoryApi class, enabling users to create multiple stories while automatically handling API rate limits. The implementation includes a retry mechanism for rate-limited requests and comprehensive logging for better debugging and monitoring.

## Key Changes
- Add `createBulk` method that accepts an array of StoryData objects
- Implement rate limit handling
- Add logging for rate limit
- Include comprehensive tests